### PR TITLE
refactor: changed config means without dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 .env
-src/.env
 .nvmrc
 node_modules
 yarn-error.log
 yarn.lock
 coverage
 *migrations
+.upmigrc.js

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ or
 ```bash
 yarn add pg-upmig
 ```
+
+## Configuration
+Either use environment variables
+```bash
+UPMIG_PATH=./migrations
+UPMIG_TABLE=pg_upmig
+```
+or use `.upmigrc.js` to set global options:
+```javascript
+module.exports = {
+  migrations: "./migrations", // Where to store migrations files
+  table: "pg_upmig", // Table name where migrations history is stored
+};
+```
 ## Migrations folder tree view
 ```
 .
@@ -54,7 +68,6 @@ Usage: pg-upmig [options] [command]
 Options:
   -V, --version   output the version number
   -h, --help      display help for command
-  -e, --env <path>         specify environment file path
   -m, --migrations <path>  specify migrations path (default: "./migrations")
   -p, --pgtable <table>    specify migration table name (default: "pg_upmig")
 
@@ -141,7 +154,6 @@ migration.up({
 |options|[Global options](#global-options)|
 |connection|[Connection parameters](#connection-parameters) for default `node-postgres` client|
 |client|[Custom postgres client](#custom-postgres-client) instance|
-|enfFile|Environment file path (.env)|
 
 ##### Global options
 |Key|Type|Description|Default|
@@ -244,7 +256,6 @@ function customFunction () {
 *Promise*
 
 Creates timestamped migration files (sql file creation is avoided when `nosql` is `true`) using `template.stub` as a template. Filename collision is handled even if this case should not happen.
-`name` is 
 
 Returns the full name of created file :
 `1600775947530_create-table`
@@ -282,3 +293,4 @@ Returns an array of objects representing migration file:
 |name|string|Migration name excluding timestamp.|
 ## Todo
 - [ ] Custom logger implementation
+- [ ] Remove dispensable dependencies

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,14 @@
-require("dotenv").config({path: "src/.env"});
+const fs = require("fs");
 
-module.exports = () => {};
+module.exports = async () => {
+    try {
+        (await fs.promises.readFile(".env")) // read config file
+        .toString("utf8") // buffer to string
+        .split(/\n|\r|\r/) // break by new line
+        .filter(item => /^\s*([\w.-]+)\s*=\s*(.*)?\s*$/.test(item)) // keep key / val
+        .map(item => {
+            const match = item.match(/^\s*([\w.-]+)\s*=\s*(.*)?\s*$/);
+            if (!Object.prototype.hasOwnProperty.call(process.env, match[1])) process.env[match[1]] = match[2].replace(/^("|')(.*)\1$/, "$2"); // set env
+        });
+    } catch (error) {}
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-upmig",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Postgresql migration tool",
   "keywords": [
     "database",
@@ -25,7 +25,6 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "commander": "^6.1.0",
-    "dotenv": "^8.2.0",
     "pg": "^8.3.3"
   },
   "devDependencies": {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -49,16 +49,12 @@ describe("Core helpers logic", () => {
     });
 
     test("setOpt function", () => {
-        cli.setOpt("env")("");
-        expect(cli._env().envFile).toBe(".env");
-        cli.setOpt("env")("null");
-        expect(cli._env().envFile).toBe("null");
         cli.setOpt("migrations")("");
-        expect(cli._env().migrationsPath).toBe("./migrations");
+        expect(cli._env().migrationsPath).toBe(fixtures.migrations);
         cli.setOpt("migrations")("null");
         expect(cli._env().migrationsPath).toBe("null");
         cli.setOpt("pgtable")("");
-        expect(cli._env().pgTable).toBe("pg_upmig");
+        expect(cli._env().pgTable).toBe(fixtures.pgTable);
         cli.setOpt("pgtable")("null");
         expect(cli._env().pgTable).toBe("null");
     });
@@ -251,7 +247,7 @@ describe("Create migration file", () => {
     });
 
     test("Init and create new migration file", async () => {
-        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
+        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
         const line = response.trim();
         expect(line).toEqual(expect.stringMatching(/Migration file created:\s+[0-9]+_.+$/i));
         const filename = line.replace(/^.+\s([0-9]+_[0-9a-z_\-]+)$/i, "$1");
@@ -260,7 +256,7 @@ describe("Create migration file", () => {
     });
 
     test("Create new migration file without sql placeholder file", async () => {
-        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.new, fixtures.migrationFile, "-n"], [], {env});
+        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.new, fixtures.migrationFile, "-n"], [], {env});
         const line = response.trim();
         expect(line).toEqual(expect.stringMatching(/Migration file created:\s+[0-9]+_.+$/i));
         const filename = line.replace(/^.+\s([0-9]+_[0-9a-z_\-]+)$/i, "$1");
@@ -283,7 +279,7 @@ describe("List pending migrations", () => {
     test("List pending migratons without history", async () => {
         const details = [];
         for (let i = 0; i <= Math.round(Math.random() * 5); i++) {
-            const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
+            const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
             details.push(created.trim().match(/\s([0-9]+)_([0-9a-z_\-]+)$/i));
         }
         const containing = [];
@@ -293,17 +289,17 @@ describe("List pending migrations", () => {
         }
         containing.push(expect.stringMatching(new RegExp(`Pending migrations:\\s+${details.length}$`, "i")));
 
-        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.list], [], {env});
+        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.list], [], {env});
         expect(response.trim().split(EOL)).toEqual(containing);
 
         // Perform left pending migrations
-        await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.perform], [], {env});
+        await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.perform], [], {env});
     });
 
     test("List pending migratons with history", async () => {
         const details = [];
         for (let i = 0; i <= Math.round(Math.random() * 5); i++) {
-            const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
+            const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
             details.push(created.trim().match(/\s([0-9]+)_([0-9a-z_\-]+)$/i));
         }
         const containing = [];
@@ -313,7 +309,7 @@ describe("List pending migrations", () => {
         }
         containing.push(expect.stringMatching(new RegExp(`Pending migrations:\\s+${details.length}/\[0\-9\]\+\\s\\(\[0\-9\]\+\\sdone\\)$`, "i")));
 
-        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.list, "-H"], [], {env});
+        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.list, "-H"], [], {env});
         expect(response.trim().split(EOL)).toEqual(containing);
     });
 });
@@ -330,9 +326,9 @@ describe("Perform pending migrations", () => {
     });
 
     test("Perform all pending migrations", async () => {
-        const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
+        const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
         const details = created.trim().match(/\s([0-9]+)_([0-9a-z_\-]+)$/i);
-        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.perform], [], {env});
+        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.perform], [], {env});
         expect(response.trim().split(EOL)).toEqual(expect.arrayContaining([
             expect.stringMatching(new RegExp(`${details[2]}\\s+${details[1]}$`, "i")),
             expect.stringMatching(/Migrations completed:\s+1$/i)
@@ -342,10 +338,10 @@ describe("Perform pending migrations", () => {
     test("Perform specific number of pending migrations", async () => {
         const details = [];
         for (let i = 0; i < 3; i++) {
-            const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
+            const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
             details.push(created.trim().match(/\s([0-9]+)_([0-9a-z_\-]+)$/i));
         }
-        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.perform, "-s", "2"], [], {env});
+        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.perform, "-s", "2"], [], {env});
         expect(response.trim().split(EOL)).toEqual(expect.arrayContaining([
             expect.stringMatching(new RegExp(`${details[0][2]}\\s+${details[0][1]}$`, "i")),
             expect.stringMatching(new RegExp(`${details[1][2]}\\s+${details[1][1]}$`, "i")),
@@ -353,17 +349,17 @@ describe("Perform pending migrations", () => {
         ]));
 
         // Perform left pending migrations
-        await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.perform], [], {env});
+        await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.perform], [], {env});
     });
 
     test("Perform pending migrations till specific timestamp", async () => {
         const details = [];
         for (let i = 0; i < 3; i++) {
-            const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
+            const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
             details.push(created.trim().match(/\s([0-9]+)_([0-9a-z_\-]+)$/i));
         }
         const ts = parseInt(details[1][1], 10) + 1;
-        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.perform, "-t", ts], [], {env});
+        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.perform, "-t", ts], [], {env});
         expect(response.trim().split(EOL)).toEqual(expect.arrayContaining([
             expect.stringMatching(new RegExp(`${details[0][2]}\\s+${details[0][1]}$`, "i")),
             expect.stringMatching(new RegExp(`${details[1][2]}\\s+${details[1][1]}$`, "i")),
@@ -371,13 +367,13 @@ describe("Perform pending migrations", () => {
         ]));
 
         // Perform left pending migrations
-        await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.perform], [], {env});
+        await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.perform], [], {env});
     });
 
     test("Perform pending migrations first condition reached (steps & timestamp)", async () => {
         const details = [];
         for (let i = 0; i <= 4; i++) {
-            const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
+            const created = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.new, fixtures.migrationFile], [], {env});
             details.push(created.trim().match(/\s([0-9]+)_([0-9a-z_\-]+)$/i));
         }
         const byTs = Math.round(Math.random() * 3);
@@ -391,7 +387,7 @@ describe("Perform pending migrations", () => {
         }
         containing.push(expect.stringMatching(new RegExp(`Migrations completed:\\s+${min+1}$`, "i")));
 
-        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, "-e", fixtures.envFile, fixtures.cli._cmds.perform, "-t", ts, "-s", bySt+1], [], {env});
+        const response = await proc.execute(["-m", fixtures.migrations, "-p", fixtures.pgTable, fixtures.cli._cmds.perform, "-t", ts, "-s", bySt+1], [], {env});
         expect(response.trim().split(EOL)).toEqual(expect.arrayContaining(containing));
     });
 });

--- a/tests/jest.fixtures.js
+++ b/tests/jest.fixtures.js
@@ -1,11 +1,10 @@
 module.exports = {
-    envFile: "src/.env",
     migrations: "./jest-migrations",
     sql: "sql",
     templateStub: "template.stub",
     pgTable: "jest_pg_upmig",
     migrationFile: "jest-up",
-    jestmigTable: "jest_mig_test",
+    jestmigTable: "jest_upmig_test",
     cli: {
         _cmds: {
             "perform": "up",
@@ -14,7 +13,6 @@ module.exports = {
         },
         globalOptions: [
             "-V, --version",
-            "-e, --env <path>",
             "-m, --migrations <path>",
             "-p, --pgtable <table>",
             "-h, --help"

--- a/tests/jest.teardown.js
+++ b/tests/jest.teardown.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const fixtures = require("./jest.fixtures.js");
 const { Client } = require("pg");
-require("dotenv").config({path: "../src/.env"});
 
 module.exports = async () => {
     try {


### PR DESCRIPTION
Removed dotenv dependency. Can parse .env when tests are run localy.
Global options (migrations path and table) can be set with env vars `UPMIG_PATH` & `UPMIG_TABLE`.
`.upmigrc.js` can override env vars. Options passed to constructor or methods prevail over previous definition.