### PR TITLE
fix: avoid ssl errors to drop connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Either use environment variables
 ```bash
 UPMIG_PATH=./migrations
 UPMIG_TABLE=pg_upmig
+UPMIG_REJECT=false
 ```
 or use `.upmigrc.js` to set global options:
 ```javascript
@@ -47,6 +48,7 @@ try {
 module.exports = {
   migrations: "./migrations", // Where to store migrations files
   table: "pg_upmig", // Table name where migrations history is stored
+  reject: false
 };
 ```
 ## Migrations folder tree view
@@ -86,6 +88,7 @@ Options:
   -h, --help      display help for command
   -m, --migrations <path>  specify migrations path (default: "./migrations")
   -p, --pgtable <table>    specify migration table name (default: "pg_upmig")
+  -r, --reject             dont ignore unauthorized ssl rejection
 
 Commands:
   up [options]    perform all pending migrations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-upmig",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Postgresql migration tool",
   "keywords": [
     "database",

--- a/src/index.js
+++ b/src/index.js
@@ -72,12 +72,21 @@ class migration {
         // Sets default database client
         if (!this.client) {
             if ((params||{}).connection) {
+                if (!params.connection.hasOwnProperty("ssl")) {
+                    params.connection.ssl= { rejectUnauthorized:  process.env.UPMIG_REJECT||false };
+                } else if (!params.connection.ssl.hasOwnProperty("rejectUnauthorized")) {
+                    params.connection.ssl["rejectUnauthorized"] = process.env.UPMIG_REJECT||false;
+                }
                 // Uses connection params
                 this.client = new Client(params.connection);
             } else {
                 // Try to connect with environment variables
                 // At this point, if nothing is provided we let PG client rise errors
-                this.client = new Client();
+                this.client = new Client({
+                    ssl: {
+                        rejectUnauthorized: process.env.UPMIG_REJECT||false
+                    }
+                });
             }
         }
     }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -21,15 +21,9 @@ afterAll(async () => {
     await teardown();
 });
 
-describe("Covering privates and specific code - fallback to default .env file", () => {
+describe("Covering privates and specific code with default env vars", () => {
     beforeAll(async () => {
-        mig = new lib({
-            options: {
-                migrations: fixtures.migrations,
-                table: fixtures.pgTable
-            },
-            envFile: "x/.env"
-        });
+        mig = new lib();
         await mig.init();
     });
 
@@ -72,12 +66,7 @@ describe("Covering privates and specific code - fallback to default .env file", 
 
 describe("Migration using environment variables", () => {
     beforeAll(async () => {
-        mig = new lib({
-            options: {
-                migrations: fixtures.migrations,
-                table: fixtures.pgTable,
-            }
-        });
+        mig = new lib();
         await mig.init();
     });
 


### PR DESCRIPTION
Adds the ability to force `rejectUnauthorizes` ssl option to avoid connection to be droped on ssl errors.