### PR TITLE
Fix: debug option is based on env vars

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ class migration {
             resultKey: "rows",
             steps: 0,
             to: 0,
-            debug: false
+            debug: String(process.env.UPMIG_DEBUG).toLowerCase() === "true"
         };
 
         try {


### PR DESCRIPTION
Now debug can be enabled with `UPMIG_DEBUG` env var set to `true`.